### PR TITLE
Update MODID to match what is generated for mcmod.info

### DIFF
--- a/minecraftpkg/Minecraft18ModTemplate/src/main/java/com/example/examplemod/ExampleMod.java
+++ b/minecraftpkg/Minecraft18ModTemplate/src/main/java/com/example/examplemod/ExampleMod.java
@@ -8,7 +8,7 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 @Mod(modid = ExampleMod.MODID, version = ExampleMod.VERSION)
 public class ExampleMod
 {
-    public static final String MODID = "examplemod";
+    public static final String MODID = "$projectname$";
     public static final String VERSION = "1.0";
     
     @EventHandler

--- a/minecraftpkg/Minecraft18ModTemplate/src/main/resources/mcmod.info
+++ b/minecraftpkg/Minecraft18ModTemplate/src/main/resources/mcmod.info
@@ -1,6 +1,6 @@
 [
 {
-  "modid": "examplemod",
+  "modid": "$projectname$",
   "name": "Example Mod",
   "description": "Example placeholder mod.",
   "version": "${version}",

--- a/minecraftpkg/MinecraftModTemplate/src/main/java/com/example/examplemod/ExampleMod.java
+++ b/minecraftpkg/MinecraftModTemplate/src/main/java/com/example/examplemod/ExampleMod.java
@@ -8,7 +8,7 @@ import cpw.mods.fml.common.event.FMLInitializationEvent;
 @Mod(modid = ExampleMod.MODID, version = ExampleMod.VERSION)
 public class ExampleMod
 {
-    public static final String MODID = "examplemod";
+    public static final String MODID = "$projectname$";
     public static final String VERSION = "1.0";
     
     @EventHandler


### PR DESCRIPTION
If the modid in mcmod.info doesn't match the modid attribute in the Java class, there is an error in the logs about being unable to find mcmod.info and the mod information is not displayed in the in-game mod list:

![image](https://cloud.githubusercontent.com/assets/3601312/7443945/e833296a-f132-11e4-8c0e-b6d90d387f6a.png)

I made it so the generated Java class uses the same template variable as mcmod.info.
